### PR TITLE
remove transferAuthorityAddress

### DIFF
--- a/dist/beta.json
+++ b/dist/beta.json
@@ -122,7 +122,6 @@
             "isPrimary": true,
             "address": "HB1cecsgnFPBfKxEDfarVtKXEARWuViJKCqztWiFB3Uk",
             "authorityAddress": "G9Ed4rdvrBypMPAz2QH6Pi9VZADkLuvo9sPvbTvHmVTU",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "SOL",
@@ -230,7 +229,6 @@
             "isPrimary": false,
             "address": "Az4MpWtMcpENQZwbEbTnrgyd2qk3wsMwQXimadUiHSQp",
             "authorityAddress": "Be3wJZnTdNerb5Ccz5kAZWcaDvwZe4XHkNZiTMtm27pQ",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "SOL",

--- a/dist/devnet.json
+++ b/dist/devnet.json
@@ -110,7 +110,6 @@
             "isPrimary": true,
             "address": "GvjoVKNjBvQcFaSKUW1gTE7DxhSpjHbE69umVR5nPuQp",
             "authorityAddress": "EhJ4fwaXUp7aiwvZThSUaGWCaBQAJe3AEaJJJVCn3UCK",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "SOL",

--- a/dist/production.json
+++ b/dist/production.json
@@ -158,7 +158,6 @@
             "isPrimary": true,
             "address": "4UpD2fh7xH3VP9QQaXtsS1YY3bxzWhtfpks7FatyKvdY",
             "authorityAddress": "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "SOL",
@@ -341,7 +340,6 @@
             "isPrimary": false,
             "address": "7RCz8wb6WXxUhAigok9ttgrVgDFFFbibcirECzWSBauM",
             "authorityAddress": "55YceCDfyvdcPPozDiMeNp9TpwmL1hdoTEFw5BMNWbpf",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "SOL",
@@ -366,7 +364,6 @@
             "isPrimary": false,
             "address": "5i8SzwX2LjpGUxLZRJ8EiYohpuKgW2FYDFhVjhGj66P1",
             "authorityAddress": "6N6tqnemGoR5pUdtKKp3FvdD94Gi98f2ySEo1dzZ2Uqv",
-            "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
             "reserves": [
                 {
                     "asset": "lsIN",
@@ -406,7 +403,8 @@
                     "collateralMintAddress": "9XtoqcLnc1psQuTPTGjfEwwabzBeUeFihvyZptcALwph",
                     "collateralSupplyAddress": "9PJCVs62fyRiQ1v9DqxD83TXDXqHabVeAUW2sHpsG13t",
                     "liquidityAddress": "CCfF5XivAg682CbZkHw4oMYj9wSTnEUeFLcn4pUjZJ8F",
-                    "liquidityFeeReceiverAddress": "Fzbt2QWmMsK7YW7AAF4nwkJMARpviPXo8CgfBX1oLD4u"
+                    "liquidityFeeReceiverAddress": "Fzbt2QWmMsK7YW7AAF4nwkJMARpviPXo8CgfBX1oLD4u",
+                    "userSupplyCap": 5000000
                 },
                 {
                     "asset": "USDC",
@@ -422,7 +420,8 @@
                     "collateralMintAddress": "E1hgwtGqjT4po2vg1LFGvf5XiZgUZBQeabcstQympPPa",
                     "collateralSupplyAddress": "B4Gsh8FpAuxvVknRny2xSvdt3T1N15RAuDrt3Yg4FDVC",
                     "liquidityAddress": "38xTjUm1egfkDojm8jesRWtpy9j3fepPAwBgAHZFQMuD",
-                    "liquidityFeeReceiverAddress": "8nzMDB9bp2BNpkL3QSgPEmCpevEhFrb8vigvLqxAzecv"
+                    "liquidityFeeReceiverAddress": "8nzMDB9bp2BNpkL3QSgPEmCpevEhFrb8vigvLqxAzecv",
+                    "userSupplyCap": 5000000
                 },
                 {
                     "asset": "SOL",

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -25,7 +25,6 @@ export interface Market {
     name: string;
     address: string;
     authorityAddress: string;
-    transferAuthorityAddress: string;
     reserves: Reserve[];
     isPrimary?: boolean;
 }

--- a/src/beta.json
+++ b/src/beta.json
@@ -122,7 +122,6 @@
       "isPrimary": true,
       "address": "HB1cecsgnFPBfKxEDfarVtKXEARWuViJKCqztWiFB3Uk",
       "authorityAddress": "G9Ed4rdvrBypMPAz2QH6Pi9VZADkLuvo9sPvbTvHmVTU",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "SOL",
@@ -230,7 +229,6 @@
       "isPrimary": false,
       "address": "Az4MpWtMcpENQZwbEbTnrgyd2qk3wsMwQXimadUiHSQp",
       "authorityAddress": "Be3wJZnTdNerb5Ccz5kAZWcaDvwZe4XHkNZiTMtm27pQ",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "SOL",

--- a/src/devnet.json
+++ b/src/devnet.json
@@ -110,7 +110,6 @@
       "isPrimary": true,
       "address": "GvjoVKNjBvQcFaSKUW1gTE7DxhSpjHbE69umVR5nPuQp",
       "authorityAddress": "EhJ4fwaXUp7aiwvZThSUaGWCaBQAJe3AEaJJJVCn3UCK",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "SOL",

--- a/src/devnet_template.json
+++ b/src/devnet_template.json
@@ -25,7 +25,6 @@
       "name": "main",
       "address": "$MAIN_MARKET_ADDRESS",
       "authorityAddress": "$MAIN_MARKET_AUTHORITY_ADDRESS",
-      "transferAuthorityAddress": "$MAIN_MARKET_TRANSFER_AUTHORITY_ADDRESS",
       "reserves": [
         {
           "asset": "SOL",

--- a/src/production.json
+++ b/src/production.json
@@ -158,7 +158,6 @@
       "isPrimary": true,
       "address": "4UpD2fh7xH3VP9QQaXtsS1YY3bxzWhtfpks7FatyKvdY",
       "authorityAddress": "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "SOL",
@@ -341,7 +340,6 @@
       "isPrimary": false,
       "address": "7RCz8wb6WXxUhAigok9ttgrVgDFFFbibcirECzWSBauM",
       "authorityAddress": "55YceCDfyvdcPPozDiMeNp9TpwmL1hdoTEFw5BMNWbpf",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "SOL",
@@ -366,7 +364,6 @@
       "isPrimary": false,
       "address": "5i8SzwX2LjpGUxLZRJ8EiYohpuKgW2FYDFhVjhGj66P1",
       "authorityAddress": "6N6tqnemGoR5pUdtKKp3FvdD94Gi98f2ySEo1dzZ2Uqv",
-      "transferAuthorityAddress": "12UzZuy8YsGv8Dj4TfsKmBu3f6unLaU4kp4Zug2tPCe5",
       "reserves": [
         {
           "asset": "lsIN",
@@ -406,7 +403,8 @@
           "collateralMintAddress": "9XtoqcLnc1psQuTPTGjfEwwabzBeUeFihvyZptcALwph",
           "collateralSupplyAddress": "9PJCVs62fyRiQ1v9DqxD83TXDXqHabVeAUW2sHpsG13t",
           "liquidityAddress": "CCfF5XivAg682CbZkHw4oMYj9wSTnEUeFLcn4pUjZJ8F",
-          "liquidityFeeReceiverAddress": "Fzbt2QWmMsK7YW7AAF4nwkJMARpviPXo8CgfBX1oLD4u"
+          "liquidityFeeReceiverAddress": "Fzbt2QWmMsK7YW7AAF4nwkJMARpviPXo8CgfBX1oLD4u",
+          "userSupplyCap": 5000000
         },
         {
           "asset": "USDC",
@@ -422,7 +420,8 @@
           "collateralMintAddress": "E1hgwtGqjT4po2vg1LFGvf5XiZgUZBQeabcstQympPPa",
           "collateralSupplyAddress": "B4Gsh8FpAuxvVknRny2xSvdt3T1N15RAuDrt3Yg4FDVC",
           "liquidityAddress": "38xTjUm1egfkDojm8jesRWtpy9j3fepPAwBgAHZFQMuD",
-          "liquidityFeeReceiverAddress": "8nzMDB9bp2BNpkL3QSgPEmCpevEhFrb8vigvLqxAzecv"
+          "liquidityFeeReceiverAddress": "8nzMDB9bp2BNpkL3QSgPEmCpevEhFrb8vigvLqxAzecv",
+          "userSupplyCap": 5000000
         },
         {
           "asset": "SOL",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,6 @@ export interface Market {
   name: string;
   address: string;
   authorityAddress: string;
-  transferAuthorityAddress: string;
   reserves: Reserve[];
   isPrimary?: boolean;
 }


### PR DESCRIPTION
Removing transferAuthorityAddress as it isn't used and shows an error on client when field isn't set. This also sets user deposit limit for step and xStep as safety precaution even though its already set in the API